### PR TITLE
Improve Python check in cmakemake.py

### DIFF
--- a/easybuild/easyblocks/generic/cmakemake.py
+++ b/easybuild/easyblocks/generic/cmakemake.py
@@ -42,14 +42,16 @@ from easybuild.easyblocks.generic.configuremake import ConfigureMake
 from easybuild.framework.easyconfig import BUILD, CUSTOM
 from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import build_option
-from easybuild.tools.filetools import change_dir, create_unused_dir, mkdir, which
+from easybuild.tools.filetools import change_dir, create_unused_dir, mkdir, read_file, which
 from easybuild.tools.environment import setvar
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
 from easybuild.tools.utilities import nub
+import easybuild.tools.toolchain as toolchain
 
 DEFAULT_CONFIGURE_CMD = 'cmake'
+
 
 def det_cmake_version():
     """
@@ -157,7 +159,6 @@ class CMakeMake(ConfigureMake):
         new_opts = ' '.join('-D%s=%s' % (key, value) for key, value in config_opts.items()
                             if '-D%s=' % key not in cfg_configopts)
         self.cfg['configopts'] = ' '.join([new_opts, cfg_configopts])
-
 
     def configure_step(self, srcdir=None, builddir=None):
         """Configure build using cmake"""
@@ -316,50 +317,52 @@ class CMakeMake(ConfigureMake):
                 self.cfg['configopts']])
 
         (out, _) = run_cmd(command, log_all=True, simple=False)
+        self.check_python_paths()
+
+        return out
+
+    def check_python_paths(self):
+        """Check that there are no detected Python paths outside the EB installed PythonF"""
+        if not os.path.exists('CMakeCache.txt'):
+            self.log.warning("CMakeCache.txt not found. Python paths checks skipped.")
+            return
+        cmake_cache = read_file('CMakeCache.txt')
+        if not cmake_cache:
+            self.log.warning("CMake Cache could not be read. Python paths checks skipped.")
+            return
 
         self.log.info("Checking Python paths")
 
-        if LooseVersion(self.cmake_version) >= '3.16':
-            try:
-                with open('CMakeCache.txt', 'r') as file:
-                    lines = file.readlines()
-            except FileNotFoundError:
-                self.log.warning("CMakeCache.txt not found. Python paths checks skipped.")
-
-            if not os.getenv('EBROOTPYTHON'):
-                self.log.warning("EBROOTPYTHON is not set.")
-        else:
-            self.log.info("Skipping Python path checks as CMake version might be lower than 3.16.")
-
         python_paths = {
             "executable": [],
-            "include": [],
+            "include_dir": [],
             "library": [],
         }
-        errors = []
-
-        for line in lines:
-            match = re.match(r"(?i)_Python(\d+)_((?:EXECUTABLE|INCLUDE_DIR|LIBRARY)):.*?=(.*)", line)
+        PYTHON_RE = re.compile(r"_?(?:Python|PYTHON)\d_(EXECUTABLE|INCLUDE_DIR|LIBRARY)[^=]*=(.*)")
+        for line in cmake_cache.splitlines():
+            match = PYTHON_RE.match(line)
             if match:
-                prefix, path_type, path = match.groups()
-                if path_type == "INCLUDE_DIR":
-                    python_paths["include"].append(path.strip())
-                    self.log.info(f"Python {path_type} path: {path}")
-                elif path_type == "EXECUTABLE":
-                    python_paths["executable"].append(path.strip())
-                    self.log.info(f"Python {path_type} path: {path}")
-                elif path_type == "LIBRARY":
-                    python_paths["library"].append(path.strip())
-                    self.log.info(f"Python {path_type} path: {path}")
+                path_type = match[1].lower()
+                path = match[2].strip()
+                self.log.info(f"Python {path_type} path: {path}")
+                python_paths[path_type].append(path)
 
-        # Validate path and handle EBROOTHPYTHON
         ebrootpython_path = get_software_root("Python")
+        if not ebrootpython_path:
+            if any(python_paths.values()) and not self.toolchain.comp_family() == toolchain.SYSTEM:
+                self.log.warning("Found Python paths in CMake cache but Python is not a dependency")
+            # Can't do the check
+            return
+        ebrootpython_path = os.path.realpath(ebrootpython_path)
+
+        errors = []
         for path_type, paths in python_paths.items():
             for path in paths:
+                if path.endswith('-NOTFOUND'):
+                    continue
                 if not os.path.exists(path):
-                    errors.append(f"Python does not exist: {path}")
-
-                if ebrootpython_path and not path.startswith(ebrootpython_path):
+                    errors.append(f"Python {path_type} does not exist: {path}")
+                elif not os.path.realpath(path).startswith(ebrootpython_path):
                     errors.append(f"Python {path_type} path '{path}' is outside EBROOTPYTHON ({ebrootpython_path})")
 
         if errors:
@@ -367,7 +370,6 @@ class CMakeMake(ConfigureMake):
             error_message = "\n".join(errors)
             raise EasyBuildError(f"Python path errors:\n{error_message}")
         self.log.info("Python check successful")
-        return out
 
     def test_step(self):
         """CMake specific test setup"""


### PR DESCRIPTION
Rather than commenting on https://github.com/easybuilders/easybuild-easyblocks/pull/3233 with a couple individual change requests I do this here with a PR to your branch. The most serious issue was that the (logged) skipping of the check wasn't actually happening.

- Reintroduce function such that missing early returns can be used
- Fix regexp (Superflous group, optional stuff)
- Simplify `python_paths` dict
- Handle the case where the cache path is "not found"
- Handle $EBROOTPYTHON not set and comparing it in the presence of symlinks
- Move `errors` variable closer to where it is used

Also some newline changes unrelated to the PR are reverted

I tested this on `Arrow-11.0.0-gfbf-2022b.eb` where it correctly detected:
```
cmakemake.py:334 INFO Checking Python paths
cmakemake.py:347 INFO Python executable path: /software/Python/3.10.8-GCCcore-12.2.0/bin/python3.10
cmakemake.py:372 INFO Python check successful
```
So I think with this the (other) PR can then be merged :)

Hope that works for you, if you spot anything feel free to ask or change.